### PR TITLE
Migrate to SHA256, finish adding filesize

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -5,7 +5,7 @@ CREATE TABLE `raws` (
   `make` char(255) NOT NULL,
   `model` char(255) NOT NULL,
   `remark` mediumtext NOT NULL,
-  `checksum` char(40) NOT NULL,
+  `checksum` char(64) NOT NULL,
   `mode` char(255) NOT NULL,
   `license` char(20) NOT NULL,
   PRIMARY KEY (`id`),

--- a/db.sql
+++ b/db.sql
@@ -5,6 +5,7 @@ CREATE TABLE `raws` (
   `make` char(255) NOT NULL,
   `model` char(255) NOT NULL,
   `remark` mediumtext NOT NULL,
+  `filesize` bigint(64) UNSIGNED NOT NULL,
   `checksum` char(64) NOT NULL,
   `mode` char(255) NOT NULL,
   `license` char(20) NOT NULL,

--- a/readme.txt
+++ b/readme.txt
@@ -1,13 +1,30 @@
 Basic setup for get it working.
 
-Requirements:
+Package requirements:
+* Web server
+* mysql server
+* php7
+* php7-cli
+* php7-mysql
+* php7-mbstring
+* exiv2
 
-Webserver with php7 + php7-cli
-Mysqldb
-exiv2
+Required config:
+* Ensure that mysqld is not in `STRICT_TRANS_TABLES` mode!
+  Query the current mode (`SELECT @@SQL_MODE;`),
+  and put the value returned (without `STRICT_TRANS_TABLES`!)
+  into `/etc/mysql/mariadb.conf.d/70-sql-mode.cnf`, e.g.:
+  ```
+  [mysqld]
+  sql_mode="ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+  ```
+* enable webserver's `php` module
+* Enable php's `pdo_mysql` module
+* Set `post_max_size = 1G` in webserver's `php.ini`
+* Set `upload_max_filesize = 1G` in webserver's `php.ini`
 
-
-1) Create database + user on mysqldb.
+1) Create database + user on mysqldb,
+   grant permissons on that database to the user.
    Use db.sql to create the tables.
 
 2) Point the webserver document root to the www directory.

--- a/tools/buildpublicdatadir.php
+++ b/tools/buildpublicdatadir.php
@@ -41,8 +41,8 @@
                 mkdir(publicdatapath."/".$make."/".$model);
             }
             symlink(datapath."/".hash_id($raw['id'])."/".$raw['id']."/".$raw['filename'],publicdatapath."/".$make."/".$model."/".$raw['filename']);
-            $sha1table[$make."/".$model."/".$raw['filename']]=$raw['checksum'];
-            
+            $sha256table[$make."/".$model."/".$raw['filename']]=$raw['checksum'];
+
             if(!in_array($make,$makes)){
                 $makes[]=$make;
             }
@@ -53,14 +53,14 @@
         }
     }
 
-    ksort($sha1table, SORT_NATURAL | SORT_FLAG_CASE);
+    ksort($sha256table, SORT_NATURAL | SORT_FLAG_CASE);
 
-    $fp=fopen(publicdatapath."/filelist.sha1","w");
-    foreach($sha1table as $file=>$sha1) {
+    $fp=fopen(publicdatapath."/filelist.sha256","w");
+    foreach($sha256table as $file=>$sha256) {
         // There are two schemes:
         // <hash><space><space><filename>      <- read in text mode
         // <hash><space><asterisk><filename>   <- read in binary mode
-        fprintf($fp,"%s *%s\n",$sha1,$file);
+        fprintf($fp,"%s *%s\n",$sha256,$file);
     }
     fclose($fp);
 

--- a/tools/buildpublicdatadirunique.php
+++ b/tools/buildpublicdatadirunique.php
@@ -43,7 +43,7 @@
                 mkdir(publicdatapathunique."/".$make."/".$model);
             }
             symlink(datapath."/".hash_id($raw['id'])."/".$raw['id']."/".$raw['filename'],publicdatapathunique."/".$make."/".$model."/".$raw['filename']);
-            $sha1table[$make."/".$model."/".$raw['filename']]=$raw['checksum'];
+            $sha256table[$make."/".$model."/".$raw['filename']]=$raw['checksum'];
 
             if(!in_array($make,$makes)){
                 $makes[]=$make;
@@ -51,14 +51,14 @@
         }
     }
 
-    ksort($sha1table, SORT_NATURAL | SORT_FLAG_CASE);
+    ksort($sha256table, SORT_NATURAL | SORT_FLAG_CASE);
 
-    $fp=fopen(publicdatapathunique."/filelist.sha1","w");
-    foreach($sha1table as $file=>$sha1) {
+    $fp=fopen(publicdatapathunique."/filelist.sha256","w");
+    foreach($sha256table as $file=>$sha256) {
         // There are two schemes:
         // <hash><space><space><filename>      <- read in text mode
         // <hash><space><asterisk><filename>   <- read in binary mode
-        fprintf($fp,"%s *%s\n",$sha1,$file);
+        fprintf($fp,"%s *%s\n",$sha256,$file);
     }
     fclose($fp);
 

--- a/tools/fixchecksum.php
+++ b/tools/fixchecksum.php
@@ -3,12 +3,18 @@
     include("../config.php");
     include("../www/functions.php");
 
+    {
+        $dbh = db_init();
+        $sth = $dbh->prepare('ALTER TABLE raws MODIFY checksum CHAR(64) NOT NULL');
+        $sth->execute();
+    }
+
     $data=raw_getalldata();
 
     foreach($data as $raw){
         $file=datapath."/".hash_id($raw['id'])."/".$raw['id']."/".$raw['filename'];
 
-        $checksum=sha1_file($file);
+        $checksum=hash_file('sha256', $file);
         if($checksum!=$raw['checksum'] ){
             echo "fixing checksum for ".$raw['filename']." : ".$checksum." =>".$raw['checksum']."\n";
             raw_modify($raw['id'],array('checksum' => $checksum));

--- a/tools/fixfilesize.php
+++ b/tools/fixfilesize.php
@@ -3,10 +3,22 @@
     include("../config.php");
     include("../www/functions.php");
 
+    {
+        $dbh = db_init();
+        $sth = $dbh->prepare('ALTER TABLE raws ADD filesize bigint(64) UNSIGNED NOT NULL;');
+        $sth->execute();
+    }
+
     $data=raw_getalldata();
 
     foreach($data as $raw){
         $file=datapath."/".hash_id($raw['id'])."/".$raw['id']."/".$raw['filename'];
+
         $filesize=filesize($file);
-        raw_modify($raw['id'],array('filesize' => $filesize));
+        if($filesize!=$raw['filesize'] ){
+            echo "fixing filesize for ".$raw['filename']." : ".$filesize." =>".$raw['filesize']."\n";
+            raw_modify($raw['id'],array('filesize' => $filesize));
+        } else {
+            echo "filesize is just fine for ".$raw['filename']."\n";
+        }
     }

--- a/www/admin.php
+++ b/www/admin.php
@@ -23,10 +23,10 @@
         <div class="ui-widget">
             <table id="repository" class="display" cellspacing="0" width="100%">
                 <thead>
-                    <tr><th>Status</th><th>Make</th><th>Model</th><th>Mode</th><th>AR</th><th>BPS</th><th>Remark</th><th>License</th><th>Checksum (sha1)</th><th>Size</th><th>Pixels</th><th>Date</th><th>Raw</th><th>Exif</th><th>Edit</th></tr>
+                    <tr><th>Status</th><th>Make</th><th>Model</th><th>Mode</th><th>AR</th><th>BPS</th><th>Remark</th><th>License</th><th>Checksum (sha256)</th><th>Size</th><th>Pixels</th><th>Date</th><th>Raw</th><th>Exif</th><th>Edit</th></tr>
                 </thead>
                 <tfoot>
-                    <tr><th>Status</th><th>Make</th><th>Model</th><th>Mode</th><th>AR</th><th>BPS</th><th>Remark</th><th>License</th><th>Checksum (sha1)</th><th>Size</th><th>Pixels</th><th>Date</th><th>Raw</th><th>Exif</th><th>Edit</th></tr>
+                    <tr><th>Status</th><th>Make</th><th>Model</th><th>Mode</th><th>AR</th><th>BPS</th><th>Remark</th><th>License</th><th>Checksum (sha256)</th><th>Size</th><th>Pixels</th><th>Date</th><th>Raw</th><th>Exif</th><th>Edit</th></tr>
                 </tfoot>
             </table>
         </div>

--- a/www/edit-admin.php
+++ b/www/edit-admin.php
@@ -84,6 +84,7 @@
             <form action="modify-admin.php" method="post">
                 <input type="hidden" id="id" name="id" value="<?php echo $tmpdata['id']?>" />
                 <input type="hidden" id="checksum" name="checksum" value="<?php echo $tmpdata['checksum']?>" />
+                <input type="hidden" id="filesize" name="filesize" value="<?php echo $tmpdata['filesize']?>" />
                 <div>
                     <label for="validated">Validated:</label>
                     <input type="checkbox" name="validated" id="validated" <?php echo $validated?>><br>
@@ -115,6 +116,10 @@
                 <div>
                     <label for="checksum">Checksum:</label>
                     <input type="text" id="checksum" name="checksum" value="<?php echo htmlspecialchars($tmpdata['checksum'])?>" />
+                </div>
+                <div>
+                    <label for="filesize">Filesize:</label>
+                    <input type="text" id="filesize" name="filesize" value="<?php echo htmlspecialchars($tmpdata['filesize'])?>" />
                 </div>
                 <div>
                     <label for="remark">Comment:</label>

--- a/www/functions.php
+++ b/www/functions.php
@@ -162,9 +162,10 @@
     function raw_add($tmpfilename,$filename) {
         $dbh = db_init();
         $checksum=hash_file('sha256', $tmpfilename);
+        $filesize=filesize($tmpfilename);
 
-        $sth = $dbh->prepare('insert into raws(filename,validated,checksum)  values(:filename,0,:checksum)');
-        $result = $sth->execute(array(':filename' => $filename,':checksum' => $checksum));
+        $sth = $dbh->prepare('insert into raws(filename,validated,checksum,filesize)  values(:filename,0,:checksum,:filesize)');
+        $result = $sth->execute(array(':filename' => $filename,':checksum' => $checksum,':filesize' => $filesize));
         if (!$result) {
             return(FALSE);
         }
@@ -194,13 +195,13 @@
         }
 
         $data['checksum']=$checksum;
+        $data['filesize']=$filesize;
         $data['make']="";
         $data['model']="";
         $data['remark']="";
         $data['mode']="";
         $data['license']="CC0";
         $data['date']=date("Y-m-d");
-        $data['filesize']=filesize($fullpath."/".$filename);
         raw_modify($id,$data);
 
         $exifdata=raw_readexif($fullpath."/".$filename,"r");

--- a/www/functions.php
+++ b/www/functions.php
@@ -161,7 +161,7 @@
 //rawfile functions
     function raw_add($tmpfilename,$filename) {
         $dbh = db_init();
-        $checksum=sha1_file($tmpfilename);
+        $checksum=hash_file('sha256', $tmpfilename);
 
         $sth = $dbh->prepare('insert into raws(filename,validated,checksum)  values(:filename,0,:checksum)');
         $result = $sth->execute(array(':filename' => $filename,':checksum' => $checksum));

--- a/www/getfile.php
+++ b/www/getfile.php
@@ -72,9 +72,9 @@
                     readfile($datapath."/".$preview);
                 }
                 break;
-            case "sha1sum":
+            case "sha256sum":
                 header('Content-Type: text/plain');
-                //header('Content-Disposition: attachment; filename="'.$data['filename'].".sha1");
+                //header('Content-Disposition: attachment; filename="'.$data['filename'].".sha256");
                 echo $data['checksum']."  ".$data['filename'];
                 break;
         }

--- a/www/getfile.php
+++ b/www/getfile.php
@@ -47,7 +47,7 @@
                 if(file_exists($file)){
                     header('Content-Type: '.mime_content_type($file));
                     header('Content-Disposition: attachment; filename="'.basename($file).'"');
-                    header('Content-Length: ' . filesize($file));
+                    header('Content-Length: ' . $data['filesize']);
                     readfile($file);
                 }
                 break;
@@ -59,7 +59,7 @@
                     $stat=stat($file);
                     header('Content-Type: '.mime_content_type($file));
                     header('Content-Disposition: attachment; filename="'.$filename.'"');
-                    header('Content-Length: ' . filesize($file));
+                    header('Content-Length: ' . $data['filesize']);
                     header('Date: ' . date("r",$stat['mtime']));
                     readfile($file);
                 }

--- a/www/json/csv.php
+++ b/www/json/csv.php
@@ -8,6 +8,6 @@
     $i=0;
     foreach($raws as $raw){
         if($raw['validated']==1) {
-            echo $raw['id'].',"'.$raw['make'].'","'.$raw['model'].'","'.$raw['mode'].'","'.$raw['remark'].'","'.$raw['license'].'","'.$raw['filename'].'","'.$raw['checksum'].'","https://raw.pixls.us/getfile.php/'.$raw['id'].'/raw/'.$raw['filename']."\"\r\n";
+            echo $raw['id'].',"'.$raw['make'].'","'.$raw['model'].'","'.$raw['mode'].'","'.$raw['remark'].'","'.$raw['license'].'","'.$raw['filename'].'","'.$raw['checksum'].'","'.$raw['filesize'].'","https://raw.pixls.us/getfile.php/'.$raw['id'].'/raw/'.$raw['filename']."\"\r\n";
         }
     }

--- a/www/json/getrepository.php
+++ b/www/json/getrepository.php
@@ -80,7 +80,7 @@
                           $raw['remark'],
                           $lic,
                           $raw['date'],
-                          "<a href='".baseurl."/getfile.php/".$raw['id']."/nice/".$nicename."'>".$nicename."</a><div class='checksumdata'><span title='SHA1 Checksum'>". $raw['checksum'] ."</span>&nbsp;(".$filesize.")</div>",
+                          "<a href='".baseurl."/getfile.php/".$raw['id']."/nice/".$nicename."'>".$nicename."</a><div class='checksumdata'><span title='sha256 Checksum'>". $raw['checksum'] ."</span>&nbsp;(".$filesize.")</div>",
                           $exifdata);
             } else if ( $set=="noncc0" and $raw['license'] != "CC0") {
                 $camera = array($make, $model);

--- a/www/modify-admin.php
+++ b/www/modify-admin.php
@@ -10,6 +10,7 @@
 
     $id = $_POST['id'] ?? '';
     $checksum = $_POST['checksum'] ?? '';
+    $filesize = $_POST['$filesize'] ?? '';
 
     if(isset($_POST['validated'])){
         $data['validated']=1;

--- a/www/modify.php
+++ b/www/modify.php
@@ -6,6 +6,7 @@
 
     $id = $_POST['id'] ?? '';
     $checksum = $_POST['checksum'] ?? '';
+    $filesize = $_POST['filesize'] ?? '';
 
     $data['make']=$_POST['make'] ?? '';
     $data['model']=$_POST['model'] ?? '';

--- a/www/upload.html
+++ b/www/upload.html
@@ -55,6 +55,7 @@
                 <form action="modify.php" method="post">
                     <input type="hidden" id="id" name="id" value="<?php echo $data['id']?>" />
                     <input type="hidden" id="checksum" name="checksum" value="<?php echo $data['checksum']?>" />
+                    <input type="hidden" id="filesize" name="filesize" value="<?php echo $data['filesize']?>" />
                         <div>
                             <label for="make" class='fcc-label'>Make</label>
                             <input class="fcc" type="text" id="make" name="make" value="<?php echo $data['make']?>" />

--- a/www/upload.php
+++ b/www/upload.php
@@ -67,6 +67,7 @@
                     <form action="modify.php" method="post">
                         <input type="hidden" id="id" name="id" value="<?php echo $data['id']?>" />
                         <input type="hidden" id="checksum" name="checksum" value="<?php echo $data['checksum']?>" />
+                        <input type="hidden" id="filesize" name="filesize" value="<?php echo $data['filesize']?>" />
                         <div>
                             <label for="make" class='fcc-label'>Make</label>
                             <input class="fcc" type="text" id="make" name="make" value="<?php echo $data['make']?>" />


### PR DESCRIPTION
Please carefully review, and after deploying run `tools/fixchecksum.php` and `tools/fixfilesize.php`.
I've tried those update paths, and then work, but YMMV.
New uploads work fine afterwards.

I'm confused why filesize handling was partially missing?

Fixes #84.