### PR TITLE
Userstats

### DIFF
--- a/tools/buildpublicdatadir.php
+++ b/tools/buildpublicdatadir.php
@@ -78,7 +78,7 @@
         }
     }
 
-    turnIntoAGitLFSRepo(publicdatagittmppath, publicdatagitrepopath_timestamped);
+    turnIntoAGitLFSRepo(publicdatagittmppath, publicdatagitrepopath_timestamped, 'data');
 
     //--------------------------------------------------------------------------
 

--- a/tools/buildpublicdatadirunique.php
+++ b/tools/buildpublicdatadirunique.php
@@ -77,7 +77,7 @@
         }
     }
 
-    turnIntoAGitLFSRepo(publicdatauniquegittmppath, publicdatauniquegitrepopath_timestamped);
+    turnIntoAGitLFSRepo(publicdatauniquegittmppath, publicdatauniquegitrepopath_timestamped, 'data-unique');
 
     //--------------------------------------------------------------------------
 

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -1,0 +1,14 @@
+RewriteEngine On
+
+# However, if we have been redirected from download-counter.php already,
+# then unmangle the filename, and cause the file download.
+# NOTE: note the [END] on the RewriteRule! Avoid endless recursion!
+RewriteCond "%{REQUEST_URI}" "^/download/"
+RewriteRule "^download/(.+)$" "$1" [END]
+
+# If we haven't been to the download-counter.php yet,
+# then rewrite the request to trigger that script.
+RewriteCond "%{REQUEST_FILENAME}" -f
+RewriteCond "%{REQUEST_URI}" "^/data(-unique)?/" [OR]
+RewriteCond "%{REQUEST_URI}" "^/data(-unique)?.git/info/refs"
+RewriteRule "^(.+)$" "/download-counter.php%{REQUEST_URI}" [L]

--- a/www/functions.php
+++ b/www/functions.php
@@ -699,3 +699,13 @@
         // Output the 36 character UUID.
         return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
     }
+
+    function parseHashsumsFile($fname) {
+        define("MAGIC", 64);
+        $arr = [];
+        foreach (file($fname, FILE_IGNORE_NEW_LINES) as $line) {
+            assert(strlen($line) >= MAGIC + 2 + 1);
+            $arr[substr($line, 0, MAGIC)] = substr($line, MAGIC + 2);
+        }
+        return $arr;
+    }

--- a/www/functions.php
+++ b/www/functions.php
@@ -684,3 +684,18 @@
         proc_close(proc_open(array('git', 'clone', '--quiet', '--mirror', $checkout, $bare), [], $pipes, $checkout, $env));
         proc_close(proc_open(array('git', 'repack', '--quiet', '-a', '-d', '-f', '-F'), [], $pipes, $bare, $env));
     }
+
+    // https://stackoverflow.com/questions/2040240/php-function-to-generate-v4-uuid/15875555#15875555
+    function guidv4($data = null) {
+        // Generate 16 bytes (128 bits) of random data or use the data passed into the function.
+        $data = $data ?? random_bytes(16);
+        assert(strlen($data) == 16);
+
+        // Set version to 0100
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+        // Set bits 6-7 to 10
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+
+        // Output the 36 character UUID.
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }

--- a/www/functions.php
+++ b/www/functions.php
@@ -655,10 +655,10 @@
         fclose($fp);
     }
 
-    function turnIntoAGitLFSRepo($checkout, $bare) {
+    function turnIntoAGitLFSRepo($checkout, $bare, $namespace) {
         $fp=fopen($checkout."/.lfsconfig","w");
         fprintf($fp,"[lfs]\n", );
-        fprintf($fp,"\turl = %s/git-lfs.php\n", baseurl);
+        fprintf($fp,"\turl = %s/git-lfs.php/$namespace\n", baseurl);
         fclose($fp);
 
         $fp=fopen($checkout."/.gitattributes","w");

--- a/www/git-lfs.php
+++ b/www/git-lfs.php
@@ -3,162 +3,197 @@
 include "../config.php";
 include "functions.php";
 
+class HTTPStatus {
+    public $code;
+    public $message;
+}
+
+class Response {
+    public $httpstatus;
+    public $response;
+}
+
+function make_response($code, $message) {
+    $httpstatus = new HTTPStatus();
+    $httpstatus->code = $code;
+    $httpstatus->message = $message;
+
+    $ret = new Response();
+    $ret->httpstatus = $httpstatus;
+    $ret->response = NULL;
+
+    return $ret;
+}
+
 // A very specific content type headers must be present.
 define("CONTENT_TYPE", "application/vnd.git-lfs+json");
-if (
-    explode(";", $_SERVER["CONTENT_TYPE"] ?? "")[0] != CONTENT_TYPE ||
-    explode(";", $_SERVER["HTTP_ACCEPT"] ?? "")[0] != CONTENT_TYPE
-) {
-    header("HTTP/1.1 406 The Accept header needs to be " . CONTENT_TYPE . ".");
-    exit();
-}
 
-header("Content-Type: " . CONTENT_TYPE);
-
-list(, $namespace, $path) = explode("/", $_SERVER["PATH_INFO"] ?? "", 3);
-
-switch($namespace) {
-    case "data":
-        define("publicurl", publicdataurl);
-        break;
-    case "data-unique":
-        define("publicurl", publicdatauniqueurl);
-        break;
-    default:
-        header("HTTP/1.1 400 Bad Request (invalid namespace)");
-        echo json_encode([
-            "message" => "Bad Request (the queried namespace is invalid)",
-        ]);
-        exit();
-}
-
-// We do not support Locking API.
-if ($path == "locks/verify") {
-    header("HTTP/1.1 403 Read-only Git LFS server");
-    echo json_encode(["message" => "This is a read-only Git LFS server"]);
-    exit();
-}
-
-// This implements Git LFS Batch API, only accept appropriate URI.
-if ($path != "objects/batch") {
-    header("HTTP/1.1 400 Bad Request (unsupported URI)");
-    echo json_encode([
-        "message" => "Bad Request (the queried URI is not supported)",
-    ]);
-    exit();
-}
-
-if ($_SERVER["REQUEST_METHOD"] != "POST") {
-    header("HTTP/1.1 400 Bad Request (not a POST verb)");
-    echo json_encode([
-        "message" => "Bad Request (all Batch API requests use the POST verb)",
-    ]);
-    exit();
-}
-
-$in = file_get_contents("php://input");
-$request = json_decode($in, true);
-
-$request["hash_algo"] = $request["hash_algo"] ?? "sha256";
-$request["transfers"] = $request["transfers"] ?? ["basic"];
-
-if (!array_key_exists("operation", $request)) {
-    header("HTTP/1.1 422 Validation error");
-    echo json_encode([
-        "message" => "Validation error (operation not specified)",
-    ]);
-    exit();
-}
-
-if ($request["operation"] == "upload") {
-    header("HTTP/1.1 403 Read-only Git LFS server");
-    echo json_encode(["message" => "This is a read-only Git LFS server"]);
-    exit();
-}
-
-if ($request["operation"] != "download") {
-    header("HTTP/1.1 422 Validation error");
-    echo json_encode([
-        "message" => "Validation error (invalid operation specified)",
-    ]);
-    exit();
-}
-
-if ($request["hash_algo"] != "sha256") {
-    header("HTTP/1.1 409 Unsupported hash algorithm");
-    echo json_encode(["message" => "Hash algorithm must be sha256"]);
-    exit();
-}
-
-if (!in_array("basic", $request["transfers"], true)) {
-    header("HTTP/1.1 409 Unsupported transfer adapter");
-    echo json_encode(["message" => "Basic transfer adapter must be supported"]);
-    exit();
-}
-
-if (!array_key_exists("objects", $request)) {
-    header("HTTP/1.1 422 Validation error");
-    echo json_encode(["message" => "Validation error (no objects specified)"]);
-    exit();
-}
-
-foreach ($request["objects"] as $object) {
+function GitLFSServer() {
     if (
-        !(count($object) == 2) ||
-        !array_key_exists("oid", $object) ||
-        !array_key_exists("size", $object) ||
-        !is_int($object["size"]) ||
-        !($object["size"] >= 0) ||
-        !is_string($object["oid"]) ||
-        !(strlen($object["oid"]) == 64) ||
-        !ctype_xdigit($object["oid"])
+        explode(";", $_SERVER["CONTENT_TYPE"] ?? "")[0] != CONTENT_TYPE ||
+        explode(";", $_SERVER["HTTP_ACCEPT"] ?? "")[0] != CONTENT_TYPE
     ) {
-        header("HTTP/1.1 422 Validation error");
-        echo json_encode([
-            "message" => "Validation error (bad object request)",
-        ]);
-        exit();
+        $ret = make_response(406, "The Accept header needs to be " . CONTENT_TYPE . ".");
+        return $ret;
     }
-}
 
-// Okay, this looks like a sensible request.
+    list(, $namespace, $path) = explode("/", $_SERVER["PATH_INFO"] ?? "", 3);
 
-$response = [];
-$response["transfer"] = "basic";
-$response["hash_algo"] = "sha256";
-$response["objects"] = [];
-
-$allraws = raw_getalldata();
-$raws = [];
-foreach ($allraws as $raw) {
-    if ($raw["validated"] == "1") {
-        $raws[$raw["checksum"] . "/" . $raw["filesize"]] = get_raw_pretty_name(
-            $raw,
-            $make,
-            $model
-        );
+    switch($namespace) {
+        case "data":
+            define("publicurl", publicdataurl);
+            break;
+        case "data-unique":
+            define("publicurl", publicdatauniqueurl);
+            break;
+        default:
+            $ret = make_response(400, "Bad Request (invalid namespace)");
+            $ret->response = [
+                "message" => "Bad Request (the queried namespace is invalid)",
+            ];
+            return $ret;
     }
-}
 
-foreach ($request["objects"] as $object) {
-    $objectResponse = [
-        "oid" => $object["oid"],
-        "size" => $object["size"],
-    ];
-    $actions = [];
-    $key = $object["oid"] . "/" . $object["size"];
-    if (array_key_exists($key, $raws)) {
-        $uri = $raws[$key];
-        $objectResponse["authenticated"] = true;
-        $actions["download"] = ["href" => publicurl . "/" . $uri];
-    } else {
-        $actions["error"] = [
-            "code" => 404,
-            "message" => "Object does not exist",
+    // We do not support Locking API.
+    if ($path == "locks/verify") {
+        $ret = make_response(403, "Read-only Git LFS server");
+        $ret->response = ["message" => "This is a read-only Git LFS server"];
+        return $ret;
+    }
+
+    // This implements Git LFS Batch API, only accept appropriate URI.
+    if ($path != "objects/batch") {
+        $ret = make_response(400, "Bad Request (unsupported URI)");
+        $ret->response = [
+            "message" => "Bad Request (the queried URI is not supported)",
         ];
+        return $ret;
     }
-    $objectResponse["actions"] = $actions;
-    $response["objects"][] = $objectResponse;
+
+    if ($_SERVER["REQUEST_METHOD"] != "POST") {
+        $ret = make_response(400, "Bad Request (not a POST verb)");
+        $ret->response = [
+            "message" => "Bad Request (all Batch API requests use the POST verb)",
+        ];
+        return $ret;
+    }
+
+    $in = file_get_contents("php://input");
+    $request = json_decode($in, true);
+
+    $request["hash_algo"] = $request["hash_algo"] ?? "sha256";
+    $request["transfers"] = $request["transfers"] ?? ["basic"];
+
+    if (!array_key_exists("operation", $request)) {
+        $ret = make_response(422, "Validation error");
+        $ret->response = [
+            "message" => "Validation error (operation not specified)",
+        ];
+        return $ret;
+    }
+
+    if ($request["operation"] == "upload") {
+        $ret = make_response(403, "Read-only Git LFS server");
+        $ret->response = ["message" => "This is a read-only Git LFS server"];
+        return $ret;
+    }
+
+    if ($request["operation"] != "download") {
+        $ret = make_response(422, "Validation error");
+        $ret->response = [
+            "message" => "Validation error (invalid operation specified)",
+        ];
+        return $ret;
+    }
+
+    if ($request["hash_algo"] != "sha256") {
+        $ret = make_response(409, "Unsupported hash algorithm");
+        $ret->response = ["message" => "Hash algorithm must be sha256"];
+        return $ret;
+    }
+
+    if (!in_array("basic", $request["transfers"], true)) {
+        $ret = make_response(409, "Unsupported transfer adapter");
+        $ret->response = ["message" => "Basic transfer adapter must be supported"];
+        return $ret;
+    }
+
+    if (!array_key_exists("objects", $request)) {
+        $ret = make_response(422, "Validation error");
+        $ret->response = ["message" => "Validation error (no objects specified)"];
+        return $ret;
+    }
+
+    foreach ($request["objects"] as $object) {
+        if (
+            !(count($object) == 2) ||
+            !array_key_exists("oid", $object) ||
+            !array_key_exists("size", $object) ||
+            !is_int($object["size"]) ||
+            !($object["size"] >= 0) ||
+            !is_string($object["oid"]) ||
+            !(strlen($object["oid"]) == 64) ||
+            !ctype_xdigit($object["oid"])
+        ) {
+            $ret = make_response(422, "Validation error");
+            $ret->response = [
+                "message" => "Validation error (bad object request)",
+            ];
+            return $ret;
+        }
+    }
+
+    // Okay, this looks like a sensible request.
+
+    $response = [];
+    $response["transfer"] = "basic";
+    $response["hash_algo"] = "sha256";
+    $response["objects"] = [];
+
+    $allraws = raw_getalldata();
+    $raws = [];
+    foreach ($allraws as $raw) {
+        if ($raw["validated"] == "1") {
+            $raws[$raw["checksum"] . "/" . $raw["filesize"]] = get_raw_pretty_name(
+                $raw,
+                $make,
+                $model
+            );
+        }
+    }
+
+    foreach ($request["objects"] as $object) {
+        $objectResponse = [
+            "oid" => $object["oid"],
+            "size" => $object["size"],
+        ];
+        $actions = [];
+        $key = $object["oid"] . "/" . $object["size"];
+        if (array_key_exists($key, $raws)) {
+            $uri = $raws[$key];
+            $objectResponse["authenticated"] = true;
+            $actions["download"] = ["href" => publicurl . "/" . $uri];
+        } else {
+            $actions["error"] = [
+                "code" => 404,
+                "message" => "Object does not exist",
+            ];
+        }
+        $objectResponse["actions"] = $actions;
+        $response["objects"][] = $objectResponse;
+    }
+
+    $ret = make_response(200, "OK");
+    $ret->response = $response;
+
+    return $ret;
 }
 
-echo json_encode($response);
+$response = GitLFSServer();
+
+header("HTTP/1.1 ".$response->httpstatus->code." ".$response->httpstatus->message);
+
+if(!is_null($response->response)) {
+   header("Content-Type: " . CONTENT_TYPE);
+   echo json_encode($response->response);
+}

--- a/www/git-lfs.php
+++ b/www/git-lfs.php
@@ -38,6 +38,7 @@ function GitLFSServer() {
     }
 
     list(, $namespace, $path) = explode("/", $_SERVER["PATH_INFO"] ?? "", 3);
+    $session = guidv4();
 
     switch($namespace) {
         case "data":
@@ -172,7 +173,12 @@ function GitLFSServer() {
         if (array_key_exists($key, $raws)) {
             $uri = $raws[$key];
             $objectResponse["authenticated"] = true;
-            $actions["download"] = ["href" => publicurl . "/" . $uri];
+            $actions["download"] = [
+                "href" => publicurl . "/" . $uri,
+                "header" => [
+                    "X-RPU-Git-LFS-Session-ID" => $session,
+                ],
+            ];
         } else {
             $actions["error"] = [
                 "code" => 404,

--- a/www/git-lfs.php
+++ b/www/git-lfs.php
@@ -15,15 +15,25 @@ if (
 
 header("Content-Type: " . CONTENT_TYPE);
 
+list(, $namespace, $path) = explode("/", $_SERVER["PATH_INFO"] ?? "", 3);
+
+if (!in_array($namespace, ["data", "data-unique"])) {
+    header("HTTP/1.1 400 Bad Request (invalid namespace)");
+    echo json_encode([
+        "message" => "Bad Request (the queried namespace is invalid)",
+    ]);
+    exit();
+}
+
 // We do not support Locking API.
-if (($_SERVER["PATH_INFO"] ?? "") == "/locks/verify") {
+if ($path == "locks/verify") {
     header("HTTP/1.1 403 Read-only Git LFS server");
     echo json_encode(["message" => "This is a read-only Git LFS server"]);
     exit();
 }
 
 // This implements Git LFS Batch API, only accept appropriate URI.
-if (($_SERVER["PATH_INFO"] ?? "") != "/objects/batch") {
+if ($path != "objects/batch") {
     header("HTTP/1.1 400 Bad Request (unsupported URI)");
     echo json_encode([
         "message" => "Bad Request (the queried URI is not supported)",

--- a/www/git-lfs.php
+++ b/www/git-lfs.php
@@ -17,12 +17,19 @@ header("Content-Type: " . CONTENT_TYPE);
 
 list(, $namespace, $path) = explode("/", $_SERVER["PATH_INFO"] ?? "", 3);
 
-if (!in_array($namespace, ["data", "data-unique"])) {
-    header("HTTP/1.1 400 Bad Request (invalid namespace)");
-    echo json_encode([
-        "message" => "Bad Request (the queried namespace is invalid)",
-    ]);
-    exit();
+switch($namespace) {
+    case "data":
+        define("publicurl", publicdataurl);
+        break;
+    case "data-unique":
+        define("publicurl", publicdatauniqueurl);
+        break;
+    default:
+        header("HTTP/1.1 400 Bad Request (invalid namespace)");
+        echo json_encode([
+            "message" => "Bad Request (the queried namespace is invalid)",
+        ]);
+        exit();
 }
 
 // We do not support Locking API.
@@ -143,7 +150,7 @@ foreach ($request["objects"] as $object) {
     if (array_key_exists($key, $raws)) {
         $uri = $raws[$key];
         $objectResponse["authenticated"] = true;
-        $actions["download"] = ["href" => publicdataurl . "/" . $uri];
+        $actions["download"] = ["href" => publicurl . "/" . $uri];
     } else {
         $actions["error"] = [
             "code" => 404,


### PR DESCRIPTION
Collect 
* `data.git`/`data-unique.git` repo clone/fetch event timestamp (+repo name)
* `git-lfs.php` request timestamp
* raw file download timestamp (+dataset name / filesize / sha256 of raw. do we want to also record make / model / etc?)
* distinqush downloads coming from git-lfs (via git-lfs `download`'s `header` entry)

I'm reasonably sure this does not increase attack surface and does not provide a data exfiltration gadget
because `download-counter.php` is only allowed to be called from within apache's internal redirect,
which is guarded by `RewriteCond "%{REQUEST_FILENAME}" -f` ensures that the request is valid.

What doesn't work: casual file downloads (via `getfile.php`) aren't tracked.
