### PR TITLE
Revert "admin: allow to filter by column value"

### DIFF
--- a/www/admin.php
+++ b/www/admin.php
@@ -73,39 +73,12 @@ $(document).ready(function() {
             null,
             null,
             null
-        ],
+		],
         "columnDefs": [
             { "type": "file-size", targets: 9 },
             { targets: 8, render: $.fn.DataTable.render.ellipsis( 16 ) },
-        ],
-        initComplete: function () {
-            this.api()
-                .columns()
-                .every(function () {
-                    let column = this;
+        ]
 
-                    // Create select element
-                    let select = document.createElement('select');
-                    select.add(new Option(''));
-                    column.footer().replaceChildren(select);
-
-                    // Apply listener for user change in value
-                    select.addEventListener('change', function () {
-                        column
-                            .search(select.value, {exact: true})
-                            .draw();
-                    });
-
-                    // Add list of options
-                    column
-                        .data()
-                        .unique()
-                        .sort()
-                        .each(function (d, j) {
-                            select.add(new Option(d));
-                        });
-                });
-        }
     } );
     $(".fc").click(function() {
         if ( $("#rights").is(':checked') & $("#edited").is(':checked') ) {


### PR DESCRIPTION
Selectable elements are from the entire table, not from the current search space.
Some styling might be missing, the UI is just too unusably wide right now.

Reverts pixlsus/raw#98