### PR TITLE
download-counter: redirect location must be url-encoded

### DIFF
--- a/www/download-counter.php
+++ b/www/download-counter.php
@@ -88,5 +88,5 @@ influxPoint("downloads",
             ]);
 
 header('HTTP/1.1 301');
-header('Location: /download'.$_SERVER["PATH_INFO"]);
+header('Location: /download'.$_SERVER["REQUEST_URI"]);
 exit();


### PR DESCRIPTION
Otherwise if there is a space in dir name, it may or may not work. Looks like at least lftp does not work.

Thanks goes to @victoryforce for bringing this to our attention.